### PR TITLE
Bring jBake and Gradle current

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,38 +1,26 @@
-
 buildscript {
     repositories {
-        mavenLocal()
-        jcenter()
-        maven {
-            url "https://oss.sonatype.org/content/groups/public"
-        }
-    }
-
-    dependencies {
-        classpath "com.ofg:uptodate-gradle-plugin:1.6.0"
-        classpath "com.github.mperry:jbake-gradle-plugin:0.3"
-        classpath "org.jbake:jbake-core:2.4.0"
-        classpath "org.asciidoctor:asciidoctorj:1.5.4"
-
-//        classpath "me.champeau.gradle:jbake-gradle-plugin:0.2.1-SNAPSHOT"
-    }
+    mavenLocal()
+    jcenter()
+    mavenCentral()
+  }
 }
 
-apply plugin: 'me.champeau.jbake'
-apply plugin: "com.ofg.uptodate"
-
-repositories {
-	jcenter()
-    maven {
-        url "https://oss.sonatype.org/content/groups/public"
-    }
+plugins {
+  id 'org.jbake.site' version '1.2.0'
+  id 'org.akhikhl.gretty' version '1.4.0'
+  id "com.ofg.uptodate" version "1.6.3"
 }
 
-dependencies {
+apply plugin: 'war'
+
+gretty {
+   httpPort = 8820
+   contextPath = '/'
+   extraResourceBases = [bake.output]
 }
 
 task publish(type: GradleBuild) {
-    buildFile = 'publish.gradle'
-    tasks = ['publishGhPages']
+   buildFile = 'publish.gradle'
+   tasks = ['publishGhPages']
 }
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip

--- a/src/jbake/jbake.properties
+++ b/src/jbake/jbake.properties
@@ -122,4 +122,4 @@ asciidoctor.attributes.export=true
 
 fj.version.stable=4.7
 fj.version.snapshot=4.8-SNAPSHOT
-gradle.version=2.14
+gradle.version=4.3


### PR DESCRIPTION
To generate

```./gradlew bake```

To validate

```./gradlew jettyRun```

The one issue I noted is that the logo is not displayed correctly when running locally (but it seems to be OK while preparing to publish).

Please review.